### PR TITLE
feat(react): Enable linting rule that enforces button types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lh",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shareable ESLint configuration used at LandscapeHub.",
   "main": "index.js",
   "peerDependencies": {

--- a/react.js
+++ b/react.js
@@ -10,6 +10,7 @@ var parserOptions = _.extend({}, base.parserOptions, {
 });
 
 var rules = _.extend({}, base.rules, {
+    "react/button-has-type": ["error"],
     "react/jsx-filename-extension": "off",
     "react/no-did-mount-set-state": "off",
     "react/no-unescaped-entities": "off",


### PR DESCRIPTION
This'll throw an error when you've got something like:

```jsx
<button className="Button">Text</button>
```

where it should be:

```jsx
<button type="button" className="Button">Text</button>
```

or

```jsx
<button type="submit" className="Button">Text</button>
```

I ran this on our app and there was only one instance of it, so I think it's safe to flip it on as an error. Thoughts?