### PR TITLE
feat(hooks): Enable exhaustive-deps rule for things like useEffect/useCallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ var rules = {
   'import/no-useless-path-segments': ['error'],
   'react/no-access-state-in-setstate': ['error'],
   'react-hooks/rules-of-hooks': 'error',
+  'react-hooks/exhaustive-deps': 'error',
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-lh",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Shareable ESLint configuration used at LandscapeHub.",
   "main": "index.js",
   "peerDependencies": {


### PR DESCRIPTION
Turns on this lint rule:

https://github.com/facebook/react/issues/14920

![image](https://user-images.githubusercontent.com/810438/54288712-d3615a00-459f-11e9-82a6-904442995d2f.gif)

It autofixes stuff, which is nice and fancy